### PR TITLE
메인의 비주얼 섹션의 MAC OS 대응 플래닛 컴포넌트 추가

### DIFF
--- a/src/components/Planet.jsx
+++ b/src/components/Planet.jsx
@@ -1,0 +1,106 @@
+import { Canvas, useFrame } from "@react-three/fiber";
+import { useMemo, useRef } from "react";
+import { BackSide } from "three";
+import { random } from "lodash";
+import "../styles/Planet.scss";
+
+const COLOR = "#F36F63";
+const DISTANCE = 100;
+
+function Satellite() {
+  const ref = useRef();
+  const timeMod = useMemo(() => random(0.1, 4, true), []);
+  const position = useMemo(() => {
+    const posMax = DISTANCE * 0.8;
+    const posMin = posMax * -1;
+    return [
+      random(posMin, posMax, true),
+      random(posMin, posMax, true),
+      random(posMin, posMax, true),
+    ];
+  }, []);
+
+  useFrame(() => {
+    ref.current.rotation.y += 0.01 * timeMod;
+  });
+
+  return (
+    <mesh position={position} ref={ref}>
+      <sphereGeometry args={[1, 30, 30]} attach="geometry" />
+      <meshStandardMaterial
+        color={COLOR}
+        roughness={0.6}
+        metalness={0.1}
+        attach="material"
+      />
+    </mesh>
+  );
+}
+
+function Satellites() {
+  const ref = useRef();
+  const cnt = 300;
+  useFrame(() => {
+    ref.current.rotation.y += 0.005;
+  });
+
+  return (
+    <group ref={ref}>
+      {Array(cnt)
+        .fill(0)
+        .map((_, idx) => (
+          <Satellite key={idx} />
+        ))}
+    </group>
+  );
+}
+
+function FixedStar() {
+  return (
+    <group>
+      <mesh>
+        <sphereBufferGeometry args={[15, 30, 30]} attach="geometry" />
+        <meshBasicMaterial color={COLOR} attach="material" />
+      </mesh>
+      <ambientLight intensity={1} />
+      <spotLight intensity={1.5} position={[0, 0, 1000]} />
+    </group>
+  );
+}
+
+function Universe() {
+  return (
+    <mesh>
+      <sphereBufferGeometry args={[DISTANCE, 32, 32]} attach="geometry" />
+      <meshStandardMaterial
+        color={COLOR}
+        side={BackSide}
+        metalness={0.4}
+        attach="material"
+      />
+    </mesh>
+  );
+}
+
+function Scene() {
+  return (
+    <>
+      <Satellites />
+      <FixedStar />
+      <Universe />
+    </>
+  );
+}
+
+function Planet({ className }) {
+  return (
+    <Canvas
+      className={`planet ${className}`}
+      camera={{ fov: 75, position: [0, 0, DISTANCE] }}
+    >
+      <Scene />
+    </Canvas>
+  );
+}
+
+export default Planet;

--- a/src/components/Visual.jsx
+++ b/src/components/Visual.jsx
@@ -1,15 +1,16 @@
 import React from "react";
 import Wave from "./Wave";
+import Planet from "./Planet";
 import { OS, getOS } from "../utils/os";
 import "../styles/Visual.scss";
 
-function Visual(props) {
+function Visual() {
   return (
     <section className="visual-wrapper">
       {getOS() === OS.MAC ? (
-        <img className="wavey-scene" src="/images/wavey.jpg" alt="Wave"></img>
+        <Planet className="visual" />
       ) : (
-        <Wave className="wavey-scene" />
+        <Wave className="visual" />
       )}
       <div className="text-wrapper">
         <span className="text">HI,</span>

--- a/src/styles/Planet.scss
+++ b/src/styles/Planet.scss
@@ -1,0 +1,3 @@
+.planet {
+  border-radius: 1rem;
+}

--- a/src/styles/Visual.scss
+++ b/src/styles/Visual.scss
@@ -42,7 +42,7 @@
     }
   }
 
-  .wavey-scene {
+  .visual {
     position: absolute !important;
     max-width: 90%;
     height: inherit !important;


### PR DESCRIPTION
1. MAC OS환경에서 보여주는 비주얼 컴포넌트 변경
- 플래닛 컴포넌트 추가.
- MAC OS환경에서 보여주는 화면을 이미지에서 플래닛 컴포넌트로 변경.